### PR TITLE
Fix warnings

### DIFF
--- a/exercise.cls
+++ b/exercise.cls
@@ -27,6 +27,7 @@
 
 % set type area
 \RequirePackage[paper=a4paper,
+                head=30.50029pt,
                 left=2.5cm,
                 right=4cm,
                 top=4cm,

--- a/exercise.cls
+++ b/exercise.cls
@@ -37,7 +37,7 @@
                 footskip=1cm]{geometry}
 
 % headings witout numbers
-\RequirePackage{scrpage2}
+\RequirePackage{scrlayer-scrpage}
 \KOMAoption{headings}{normal}
 \setcounter{secnumdepth}{0}
 
@@ -108,8 +108,8 @@
 }
 
 % layout of head and foot
-\setheadtopline{1pt}
-\setheadsepline{0.2pt}
+\KOMAoption{headtopline}{1pt}
+\KOMAoption{headsepline}{0.2pt}
 \setfootwidth{textwithmarginpar}
 \setkomafont{pageheadfoot}{\small\sffamily}
 \setkomafont{pagefoot}{\large\sffamily}


### PR DESCRIPTION
This pull request fixes the two following warnings:
`Package scrpage2 Warning: usage of obsolete package!`
`Package scrlayer-scrpage Warning: \headheight to low.`
