### PR TITLE
Add checkmark and x mark

### DIFF
--- a/exercise.cls
+++ b/exercise.cls
@@ -176,6 +176,11 @@
 % nice tick
 \newcommand{\tick}{\checkmark}
 
+% optional checkmark and x mark
+\RequirePackage{pifont}
+\providecommand{\cmark}{\ding{51}}
+\providecommand{\xmark}{\ding{55}}
+
 % often used sets
 \newcommand{\set}[1]{\mathbb{#1}}
 \newcommand{\R}{\set{R}}


### PR DESCRIPTION
The \tick command provides a checkmark which is not the same style as the x mark hence adding both.