### PR TITLE
Use \clearpairofpagestyles instead of \clearscrheadfoot

### DIFF
--- a/exercise.cls
+++ b/exercise.cls
@@ -197,7 +197,7 @@
 
 % content of head and foot
 \pagestyle{scrheadings}
-\clearscrheadfoot
+\clearpairofpagestyles
 \automark{section}
 \newcommand{\setgroup}[1]{\ihead{#1}}
 


### PR DESCRIPTION
Compilation results in a warning that says the newer version should be used.